### PR TITLE
Update terraform-aws-util module to latest version

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -14,67 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: terraform setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
       #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-
-#     TODO: This step duplicates work done by the Makefile.
-#     - name: check terraform formatting
-#       id: fmt
-#       run: |
-#         terraform fmt -check -recursive
 
       - name: run make
       # env:
       #   TOKEN: ${{ secrets.TOKEN }}
         run: |
           make all
-
-#     - name: terraform init
-#       id: init
-#       run: terraform init
-#
-#      - name: terraform plan
-#        id: plan
-#        if: github.event_name == 'pull_request'
-#        run: terraform plan -no-color
-#        continue-on-error: true
-#
-#      - uses: actions/github-script@0.9.0
-#        if: github.event_name == 'pull_request'
-#        env:
-#          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
-#        with:
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          script: |
-#            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
-#            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-#            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-#
-#            <details><summary>Show Plan</summary>
-#
-#            \`\`\`${process.env.PLAN}\`\`\`
-#
-#            </details>
-#
-#            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
-#
-#              
-#            github.issues.createComment({
-#              issue_number: context.issue.number,
-#              owner: context.repo.owner,
-#              repo: context.repo.repo,
-#              body: output
-#            })
-#
-#      - name: terraform plan status
-#        if: steps.plan.outcome == 'failure'
-#        run: exit 1
-#
-#      - name: terraform apply
-#        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-#        run: terraform apply -auto-approve

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REPO := $(shell basename $(shell git remote get-url origin) .git)
 all: test
 
 test: .terraform
-	AWS_DEFAULT_REGION=us-east-2 terraform validate
+	terraform validate
 	terraform fmt -check
 	! egrep "TF-UPGRADE-TODO|cites-illinois|as-aws-modules" *.tf README.md
 	# Do NOT put terraform-aws in the title

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "get-subnets" {
-  source = "github.com/techservicesillinois/terraform-aws-util//modules/get-subnets?ref=v3.0.4"
+  source = "github.com/techservicesillinois/terraform-aws-util//modules/get-subnets?ref=v3.0.5"
 
   include_subnets_by_az = true
   subnet_type           = var.subnet_type


### PR DESCRIPTION
The legacy 'tier' variable in the terraform-aws-util module has been retired. Accordingly, bump this module to refer to latest version of terraform-aws-util.